### PR TITLE
CarrierWaveの導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+/public/uploads

--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,11 @@ gem 'bootstrap'
 # deviseの導入
 gem 'devise'
 
+# CarrierWaveの導入
+gem 'carrierwave'
+gem 'rmagick'
+
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,14 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    carrierwave (2.2.2)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      marcel (~> 1.0.0)
+      mini_mime (>= 0.1.3)
+      ssrf_filter (~> 1.0)
     childprocess (4.1.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
@@ -102,6 +110,9 @@ GEM
       activesupport (>= 5.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    image_processing (1.12.2)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
@@ -120,6 +131,7 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mini_magick (4.11.0)
     mini_mime (1.1.2)
     minitest (5.16.2)
     msgpack (1.5.4)
@@ -185,6 +197,9 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.5)
+    rmagick (4.2.6)
+    ruby-vips (2.1.4)
+      ffi (~> 1.12)
     rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -210,6 +225,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    ssrf_filter (1.1.0)
     thor (1.2.1)
     tilt (2.0.11)
     turbolinks (5.2.1)
@@ -251,6 +267,7 @@ DEPENDENCIES
   bootstrap
   byebug
   capybara (>= 3.26)
+  carrierwave
   devise
   jbuilder (~> 2.7)
   jquery-rails
@@ -261,6 +278,7 @@ DEPENDENCIES
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.4)
   rails-flog
+  rmagick
   sass-rails (>= 6)
   selenium-webdriver
   spring

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -35,12 +35,6 @@ class PostsController < ApplicationController
       @post = Post.find(params[:id])
       @comment = Comment.new
       @comments = @post.comments.includes(:user)
-
-      if @post.status_private? && @post.user != current_user
-        respond_to do |format|
-          format.html { redirect_to posts_path, notice: 'このページにはアクセスできません' }
-        end
-      end
       
   end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,6 +4,8 @@ class Post < ApplicationRecord
     enum status: { open: 0, hidden: 1 }, _prefix: true
     self.inheritance_column = :_type_disabled
 
+    mount_uploader :image, ImageUploader
+
     belongs_to :user
     has_many :comments, dependent: :destroy
     has_many :post_tags, dependent: :destroy

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -1,0 +1,47 @@
+class ImageUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add an allowlist of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_allowlist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -13,11 +13,11 @@
   </div>
 
   <div class="field">
-    <%= f.label :type, '投稿の種類' %><br />
-    <%= f.label :type, :"教育" %>
-    <%= f.radio_button :type, :education %>
-    <%= f.label :type, :"相談" %>
-    <%= f.radio_button :type, :advise %>
+    <%= f.label :post_type, '投稿の種類' %><br />
+    <%= f.label :post_type, :"教育" %>
+    <%= f.radio_button :post_type, :education %>
+    <%= f.label :post_type, :"相談" %>
+    <%= f.radio_button :post_type, :advise %>
   </div>
 
   <div class="field"><br>
@@ -46,4 +46,6 @@
   <div class="actions"><br>
     <%= f.submit "保存する", class: :form__btn  %>
   </div>
-<% end %>
+<% end %><br>
+
+<button><%= link_to "投稿一覧に戻る", root_path %></button>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -31,7 +31,15 @@
     <% @posts.each do |post| %>
         <div class="col-md-4 rounded-circle">
           <div class="card mb-4 shadow-sm">
-            <img class="card-img-top" data-src="holder.js/100px225?theme=thumb&amp;bg=55595c&amp;fg=eceeef&amp;text=Thumbnail" alt="Thumbnail [100%x225]" style="height: 225px; width: 100%; display: block;" src="data:image/svg+xml;charset=UTF-8,%3Csvg%20width%3D%22288%22%20height%3D%22225%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20288%20225%22%20preserveAspectRatio%3D%22none%22%3E%3Cdefs%3E%3Cstyle%20type%3D%22text%2Fcss%22%3E%23holder_182ecefb578%20text%20%7B%20fill%3A%23eceeef%3Bfont-weight%3Abold%3Bfont-family%3AArial%2C%20Helvetica%2C%20Open%20Sans%2C%20sans-serif%2C%20monospace%3Bfont-size%3A14pt%20%7D%20%3C%2Fstyle%3E%3C%2Fdefs%3E%3Cg%20id%3D%22holder_182ecefb578%22%3E%3Crect%20width%3D%22288%22%20height%3D%22225%22%20fill%3D%22%2355595c%22%3E%3C%2Frect%3E%3Cg%3E%3Ctext%20x%3D%2296.828125%22%20y%3D%22118.8%22%3EThumbnail%3C%2Ftext%3E%3C%2Fg%3E%3C%2Fg%3E%3C%2Fsvg%3E" data-holder-rendered="true">
+
+            <% if post.image? %>  <!-- アップロード画像がある場合に実行する -->
+
+            <img class="card-img-top">
+            <strong>画像</strong><br>
+              <%= image_tag post.image.url %>
+          <% end %>
+
+            <img class="card-img-top">
               <div class="card-body">
                 <!-- <p class="card-text">This is a wider card with supporting text below as a natural lead-in to additional content. This content is a little bit longer.</p> -->
                 <p class="card-text"> <%= post.title %></p>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -8,14 +8,11 @@
 </div>
 
 <div>
-    <p>
-      <%= @post.title %>
-    </p>
     <%= link_to "by" + @post.user.name, root_path %>
       <div>
         <%= link_to "編集する", edit_post_path(@post) %>
         <%= link_to "削除する", post_path(@post), method: :delete %>
-      </div>
+      </div><br>
       <ul>
       <% @post.tags.each do |tag| %>
         <li><span><%= tag.name %></span></li>
@@ -28,11 +25,16 @@
           <%= @post.title %>
         </p>
       </div>
-      <% if @post.image == nil? %>
-        <div>
-        <%= image_tag @post.image %>
-        </div>
-      <% end %>
+
+      <div>
+        <p>画像</p>
+        <% if @post.image? %>  <!-- アップロード画像がある場合に実行する -->
+          <p>
+          <%= image_tag @post.image.url, size: '320x240' %><!-- userインスタンスの画像ファイルのURLを取得し表示 -->
+          </p>
+        <% end %>
+      </div>
+
         <div>
           <p>内容</p>
           <p>
@@ -63,4 +65,6 @@
             <%= f.radio_button :status, :hidden %><br>
             <%= f.submit "SEND" %>
           <% end %>
-        <% end %>
+        <% end %><br>
+
+        <button><%= link_to "投稿一覧に戻る", root_path %></button>

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,3 +3,4 @@ require_relative "application"
 
 # Initialize the Rails application.
 Rails.application.initialize!
+require 'carrierwave/orm/activerecord'

--- a/db/migrate/20220830092021_rename_type_column_to_posts.rb
+++ b/db/migrate/20220830092021_rename_type_column_to_posts.rb
@@ -1,0 +1,5 @@
+class RenameTypeColumnToPosts < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :posts, :type, :post_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_23_081050) do
+ActiveRecord::Schema.define(version: 2022_08_30_092021) do
 
   create_table "admins", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -69,7 +69,7 @@ ActiveRecord::Schema.define(version: 2022_08_23_081050) do
 
   create_table "posts", charset: "utf8", force: :cascade do |t|
     t.bigint "user_id"
-    t.integer "type"
+    t.integer "post_type"
     t.string "title", null: false
     t.text "content", null: false
     t.string "image"


### PR DESCRIPTION
# 概要
- CarrierWaveの導入

# 詳細
- CarrierWaveの導入
  - `Gemfile`に`gem 'carrierwave'` と`gem 'rmagick'`を追記しbundle install
  - `rails g uploader Image`で`app/uploaders/image_uploader.rb`を生成
  - `app/models/post.rb`に` mount_uploader :image, ImageUploader`を追記
  - `config/environment.rb`に `require 'carrierwave/orm/activerecord'`を追記
  - ビューファイルの編集 `app/views/posts/_form.html.erb` `app/views/posts/index.html.erb` `app/views/posts/show.html.erb`（ 画像がある場合は表示するよう条件分岐）

- `app/controllers/posts_controller.rb`のshowアクションの不要な記述を削除
- Postsテーブルのカラム名'type'を'post＿typeに変更'　`db/migrate/20220830092021_rename_type_column_to_posts.rb`
  - カラム名の変更に伴い、ビューファイルを編集 `app/views/posts/_form.html.erb` 