### PR TITLE
エラーメッセージの日本語化

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,7 @@ class MessagesController < ApplicationController
           redirect_to room_path(@message.room_id)
         end
       else
-        flash[:alert] = "メッセージの送信に失敗しました。"
+        redirect_to room_path(@message.room_id)
       end
     end
    

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -4,7 +4,5 @@ class Message < ApplicationRecord
 
 
 
-    with_options presence: true do
-        validates :content
-    end
+    validates :content, presence: true
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,6 @@
 class Post < ApplicationRecord
 
-    enum post_type: { education: 0, advise: 1, other: 3 }, _prefix: true
+    enum post_type: { education: 0, advise: 1, other: 2 }, _prefix: true
     enum status: { open: 0, hidden: 1 }, _prefix: true
     self.inheritance_column = :_type_disabled
 
@@ -18,7 +18,7 @@ class Post < ApplicationRecord
 
 
 
-    with_options presence: true, on: :publicize do
+    with_options presence: true do
         validates :title
         validates :content
         validates :status

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -3,4 +3,5 @@ class Room < ApplicationRecord
     has_many :messages, dependent: :destroy
 
 
+
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -3,7 +3,7 @@
   <div class="row">
     <div class="col-md-6 col-md-offset-3 form-wrapper">
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-        <%= render "devise/shared/error_messages", resource: resource %>
+        <%= render 'layouts/error_messages', model: f.object %>
         <div class = 'form-group'>
           <%= f.label :name, "ユーザー名" %>
           <%= f.text_field :name, autofocus: true, class: "form-control", placeholder: "最大10文字", maxlength: 10 %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,7 +1,7 @@
 <h2>新規登録</h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= render 'layouts/error_messages', model: f.object %>
 
   <br>
 
@@ -13,13 +13,13 @@
 
   <div class="field">
     <%= f.label :name, '名前' %><br />
-    <%= f.text_field :name, placeholder:'学校太郎', autofocus: true %>
+    <%= f.text_field :name, autofocus: true, placeholder:'最大10文字' %>
   </div>
 
   <br>
   <div class="field">
     <%= f.label :email %><br />
-    <%= f.email_field :email, placeholder:'(例)t-talk@school.com', autofocus: true, autocomplete: "email" %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder:'xxx@email.com' %>
   </div>
 
   <br>
@@ -28,19 +28,19 @@
     <% if @minimum_password_length %>
     <em>(<%= @minimum_password_length %> characters minimum)</em>
     <% end %><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
+    <%= f.password_field :password, autocomplete: "new-password", placeholder: "半角英数6文字以上" %>
   </div>
 
   <br>
   <div class="field">
     <%= f.label :password（確認用） %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "再度ご入力ください" %>
   </div>
 
   <br>
   <div class="field">
     <%= f.label :birth, '生年月日' %><br />
-    <%= f.text_field :birth, placeholder:'(例)2022年1月1日', autofocus: true %>
+    <%= f.text_field :birth, autofocus: true, placeholder:'xxxx年x月x日' %>
   </div>
 
   <br>
@@ -53,7 +53,7 @@
   <br>
   <div class="field">
     <%= f.label :affiliation, '所属校' %><br />
-    <%= f.text_field :affiliation, placeholder:'(例) ○○県××市立△△小学校', autofocus: true %>
+    <%= f.text_field :affiliation, autofocus: true, placeholder:'○○県××市立△△小学校' %>
   </div><br>
 
   <div class='field'>

--- a/app/views/layouts/_error_messages.html.erb
+++ b/app/views/layouts/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if model.errors.any? %>
+  <div class="alert alert-warning">
+    <ul>
+      <% model.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,4 +1,5 @@
 <%= form_with model: @post, local: true do |f|%>
+<%= render 'layouts/error_messages', model: f.object %>
 
   <div class="check_box">
     <span>タグ</span>

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -31,14 +31,15 @@
             <p>メッセージはまだありません</p>
         <% end %>
       </div>
-      #// メッセージ表示部分
+      #// メッセージ表示部分<br>
       
       # メッセージ投稿フォーム
       <div class="posts">
         <%= form_with model: @message, local: true do |f| %>
+          <%= render 'layouts/error_messages', model: f.object %>
           <%= f.text_field :content, placeholder: "メッセージを入力してください" %><br>
           <%= f.file_field :image %>
-          <%= f.hidden_field :room_id, value: @room.id %>
+          <%= f.hidden_field :room_id, value: @room.id %><br>
           <%= f.submit "送信する" %>
         <% end %>
       </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -10,13 +10,13 @@
 
   <div class="field">
     <%= f.label :name, '名前' %><br />
-    <%= f.text_field :name, autofocus: true %>
+    <%= f.text_field :name, autofocus: true, placeholder:'最大10文字' %>
   </div>
 
   <br>
   <div class="field">
     <%= f.label :birth, '生年月日' %><br />
-    <%= f.text_field :birth, placeholder:'2022年1月1日', autofocus: true %>
+    <%= f.text_field :birth, autofocus: true, placeholder:'xxxx年x月x日' %>
   </div>
 
   <br>
@@ -30,7 +30,7 @@
   <br>
   <div class="field">
     <%= f.label :affiliation, '所属校' %><br />
-    <%= f.text_field :affiliation, placeholder:'例 ○○県××市立△△小学校', autofocus: true %>
+    <%= f.text_field :affiliation, autofocus: true, placeholder:'○○県××市立△△小学校' %>
   </div><br>
 
   <div class='field'>
@@ -58,7 +58,7 @@
   <br>
   <div class="field">
     <%= f.label :responsible, '主な校務分掌' %><br />
-    <%= f.text_field :responsible, placeholder:'校務分掌がない場合は”なし”とご入力ください。', autofocus: true %>
+    <%= f.text_field :responsible, autofocus: true, placeholder:'校務分掌がない場合は”なし”とご入力ください。' %>
   </div>
 
   <br>

--- a/config/application.rb
+++ b/config/application.rb
@@ -13,7 +13,7 @@ module App
     config.paths.add 'lib', eager_load: true
     config.time_zone = 'Tokyo'
     config.i18n.default_locale = :ja
-    config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '*.{rb,yml}').to_s]
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -1,0 +1,143 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,27 @@
 ja:
+  activerecord:
+    attributes:
+      user:
+        name: '名前'
+        birth: '生年月日'
+        gender: "性別"
+        affiliation: "所属校"
+        job_title: "職名"
+        career: "教員歴"
+        responsible: "主な校務分掌"
+        subject: "担当教科"
+        grade: "担当学年"
+        other: "その他"
+        introduction: '自己紹介'
+      post:
+        title: 'タイトル'
+        content: '投稿内容'
+        post_type: '投稿のカテゴリ'
+        status: '公開範囲'
+      message:
+        content: 'メッセージ'
+      position:
+        name: '校務分掌'
   enums:
     user:
       gender:

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -21,11 +21,11 @@ ja:
       post:
         id: "投稿番号"
         user_id: "ユーザーid"
-        type: "投稿の種類"
+        type: "投稿のカテゴリ"
         title: "タイトル"
         content: "投稿内容"
         image: "画像"
-        status: "公開・非公開"
+        status: "公開範囲"
         created_at: "作成日"
         updated_at: "更新日"
       user:
@@ -45,8 +45,11 @@ ja:
         current_sign_in_at: "ログイン状態"
         sign_in_count: "ログイン回数"
         created_at: "作成日"
+      message:
+        content: 'メッセージ'
       notice:
         title: "タイトル"
         content: "内容"
+
 
 


### PR DESCRIPTION
#概要
- エラーメッセージの日本語化
- その他修正

#詳細
- エラーメッセージの日本語化
  - エラーメッセージ表示ファイルのテンプレート化`app/views/layouts/_error_messages.html.erb`
  - エラーメッセージのカラムの日本語化`config/locales/ja.yml``config/locales/model.ja.yml`
  - deviseのエラーメッセージの日本語化`config/locales/devise.ja.yml`
  - ビューファイルにエラーメッセージの部分テンプレートを挿入`app/views/devise/registrations/new.html.erb``app/views/devise/registrations/edit.html.erb``app/views/users/edit.html.erb``app/views/posts/_form.html.erb``app/views/rooms/show.html.erb`
- その他修正
  - placeholderの修正
    - `app/views/users/edit.html.erb` `app/views/devise/registrations/new.html.erb``app/views/devise/registrations/edit.html.erb`
    - リダイレクト先の変更`app/controllers/messages_controller.rb`
    - enum otherの数字変更とバリデーションの[on: :publicize]を削除 `app/models/post.rb`